### PR TITLE
Error when encoding fixed-length buffers of incorrect size

### DIFF
--- a/index.js
+++ b/index.js
@@ -342,6 +342,7 @@ exports.bool = {
 const fixed = exports.fixed = function fixed (n) {
   return {
     preencode (state, s) {
+      if (s.byteLength !== n) throw new Error('Incorrect buffer size')
       state.end += n
     },
     encode (state, s) {

--- a/test.js
+++ b/test.js
@@ -423,6 +423,19 @@ test('fixed n', function (t) {
   t.exception(() => fixed.decode(state))
 })
 
+test('error for incorrect buffer sizes when encoding fixed-length buffers', function (t) {
+  const smallbuf = b4a.from('aa', 'hex')
+  const bigBuf = b4a.from('aa'.repeat(500), 'hex')
+
+  t.exception(() => enc.encode(enc.fixed32, smallbuf), /Incorrect buffer size/)
+  t.exception(() => enc.encode(enc.fixed64, smallbuf), /Incorrect buffer size/)
+  t.exception(() => enc.encode(enc.fixed(100), smallbuf), /Incorrect buffer size/)
+
+  t.exception(() => enc.encode(enc.fixed32, bigBuf), /Incorrect buffer size/)
+  t.exception(() => enc.encode(enc.fixed64, bigBuf), /Incorrect buffer size/)
+  t.exception(() => enc.encode(enc.fixed(100), bigBuf), /Incorrect buffer size/)
+})
+
 test('array', function (t) {
   const state = enc.state()
   const arr = enc.array(enc.bool)


### PR DESCRIPTION
Previous behaviour was:
- Too-small buffers: 0 pad them
- Too-large buffers: throw a range error

Now it throws a normal error for both cases
