### PR TITLE
Add BigInt schemaless support

### DIFF
--- a/index.js
+++ b/index.js
@@ -604,7 +604,9 @@ const anyTypes = [
   exports.float64,
   anyArray,
   anyObject,
-  exports.date
+  exports.date,
+  exports.biguint,
+  exports.bigint
 ]
 
 const any = exports.any = {
@@ -637,6 +639,9 @@ function getType (o) {
   if (Array.isArray(o)) return 7
   if (o instanceof Date) return 9
   if (typeof o === 'object') return 8
+  if (typeof o === 'bigint') {
+    return o >= 0n ? 10 : 11
+  }
 
   throw new Error('Unsupported type for ' + o)
 }

--- a/test.js
+++ b/test.js
@@ -824,7 +824,9 @@ test('any', function (t) {
     arr: [{ yes: 1 }, { no: false }],
     nest: {},
     today: new Date(),
-    float: 0.54
+    float: 0.54,
+    big: 42n,
+    bign: -42n
   }
 
   t.alike(enc.decode(enc.any, enc.encode(enc.any, o)), o)


### PR DESCRIPTION
It would be cool to ignore `function` types, will do another PR after this one