### PR TITLE
Add Function schemaless support

### DIFF
--- a/index.js
+++ b/index.js
@@ -626,7 +626,7 @@ const any = exports.any = {
 }
 
 function getType (o) {
-  if (o === null || o === undefined) return 0
+  if (o === null || o === undefined || typeof o === 'function') return 0
   if (typeof o === 'boolean') return 1
   if (typeof o === 'string') return 2
   if (b4a.isBuffer(o)) return 3

--- a/index.js
+++ b/index.js
@@ -568,7 +568,7 @@ const anyArray = {
 
 const anyObject = {
   preencode (state, o) {
-    const keys = Object.keys(o)
+    const keys = objectKeysMinusFn(o)
     uint.preencode(state, keys.length)
     for (const key of keys) {
       utf8.preencode(state, key)
@@ -576,7 +576,7 @@ const anyObject = {
     }
   },
   encode (state, o) {
-    const keys = Object.keys(o)
+    const keys = objectKeysMinusFn(o)
     uint.encode(state, keys.length)
     for (const key of keys) {
       utf8.encode(state, key)
@@ -763,4 +763,13 @@ function zigZagEncodeBigInt (n) {
 
 function validateUint (n) {
   if ((n >= 0) === false /* Handles NaN as well */) throw new Error('uint must be positive')
+}
+
+function objectKeysMinusFn (o) {
+  const keys = []
+  for (const key in o) {
+    if (typeof o[key] === 'function') continue
+    keys.push(key)
+  }
+  return keys
 }

--- a/test.js
+++ b/test.js
@@ -839,9 +839,7 @@ test('any function', function (t) {
     fn: function () {}
   }
 
-  t.alike(enc.decode(enc.any, enc.encode(enc.any, obj)), {
-    fn: null
-  })
+  t.alike(enc.decode(enc.any, enc.encode(enc.any, obj)), {})
 
   const arr = [
     function () {}

--- a/test.js
+++ b/test.js
@@ -834,6 +834,24 @@ test('any', function (t) {
   t.alike(enc.decode(enc.any, enc.encode(enc.any, arr)), [null, null, null])
 })
 
+test('any function', function (t) {
+  const obj = {
+    fn: function () {}
+  }
+
+  t.alike(enc.decode(enc.any, enc.encode(enc.any, obj)), {
+    fn: null
+  })
+
+  const arr = [
+    function () {}
+  ]
+
+  t.alike(enc.decode(enc.any, enc.encode(enc.any, arr)), [
+    null
+  ])
+})
+
 test('framed', function (t) {
   const e = enc.frame(enc.uint)
   t.alike(enc.encode(e, 42), b4a.from([0x01, 0x2a]))


### PR DESCRIPTION
Nullifying it is the simplest way and it should be ok, but the last commit makes it behave more like JSON by completely removing the property