### PR TITLE
Signed Lexicographic Integer & Date encoders

### DIFF
--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ to build others on top. Feel free to PR more that are missing.
 - `cenc.fixed64` - Encodes a fixed 64 byte buffer.
 - `cenc.fixed(n)` - Makes a fixed sized encoder.
 - `cenc.date(d)` - Encodes a date object.
+- `cenc.lexdate(d)` - Encodes a date object preserving lexicographic ordering.
 - `cenc.array(enc)` - Makes an array encoder from another encoder. Arrays are uint prefixed with their length.
 - `cenc.raw.array(enc)` - Makes an array encoder from another encoder, without a length prefixed.
 - `cenc.json` - Encodes a JSON value as utf-8.

--- a/index.js
+++ b/index.js
@@ -247,6 +247,7 @@ const biguint = (exports.biguint = {
 exports.bigint = zigZagBigInt(biguint)
 
 exports.lexint = require('./lexint')
+exports.signedLexint = require('./signed-lexint')
 
 exports.float32 = {
   preencode(state, n) {

--- a/index.js
+++ b/index.js
@@ -545,6 +545,18 @@ exports.date = {
   }
 }
 
+exports.lexdate = {
+  preencode(state, d) {
+    exports.signedLexint.preencode(state, d.getTime())
+  },
+  encode(state, d) {
+    exports.signedLexint.encode(state, d.getTime())
+  },
+  decode(state, d) {
+    return new Date(exports.signedLexint.decode(state))
+  }
+}
+
 exports.json = {
   preencode(state, v) {
     utf8.preencode(state, JSON.stringify(v))

--- a/signed-lexint.js
+++ b/signed-lexint.js
@@ -1,0 +1,24 @@
+const lexint = require('./lexint.js')
+
+function preencode(state, num) {
+  const positive = num >= 0
+  state.end++ // Add byte for sign bit
+  lexint.preencode(state, num * (positive ? 1 : -1))
+}
+
+function encode(state, num) {
+  const positive = num >= 0
+  state.buffer[state.start++] = positive ? 1 : 0
+  lexint.encode(state, num * (positive ? 1 : -1))
+}
+
+function decode(state) {
+  const positive = state.buffer[state.start++]
+  return (positive ? 1 : -1) * lexint.decode(state)
+}
+
+module.exports = {
+  preencode,
+  encode,
+  decode
+}

--- a/signed-lexint.js
+++ b/signed-lexint.js
@@ -1,4 +1,4 @@
-const lexint = require('./lexint.js')
+const lexint = require('./lexint')
 
 function preencode(state, num) {
   const positive = num >= 0
@@ -10,10 +10,20 @@ function encode(state, num) {
   const positive = num >= 0
   state.buffer[state.start++] = positive ? 1 : 0
   lexint.encode(state, num * (positive ? 1 : -1))
+  if (!positive) {
+    for (let i = 1; i < state.end; i++) {
+      state.buffer[i] = state.buffer[i] ^ 0xff
+    }
+  }
 }
 
 function decode(state) {
   const positive = state.buffer[state.start++]
+  if (!positive) {
+    for (let i = 1; i < state.end; i++) {
+      state.buffer[i] = state.buffer[i] ^ 0xff
+    }
+  }
   return (positive ? 1 : -1) * lexint.decode(state)
 }
 

--- a/signed-lexint.js
+++ b/signed-lexint.js
@@ -1,30 +1,145 @@
 const lexint = require('./lexint')
 
 function preencode(state, num) {
-  const positive = num >= 0
-  state.end++ // Add byte for sign bit
-  lexint.preencode(state, num * (positive ? 1 : -1))
+  num = Math.abs(num) // Ignore sign
+  if (num < 123) {
+    state.end++
+  } else if (num < 128) {
+    state.end += 2
+  } else if (num < 0x10000) {
+    state.end += 3
+  } else if (num < 0x1000000) {
+    state.end += 4
+  } else if (num < 0x100000000) {
+    state.end += 5
+  } else {
+    state.end++
+    const exp = Math.floor(Math.log(num) / Math.log(2)) - 32
+    preencode(state, exp)
+    state.end += 6
+  }
 }
 
 function encode(state, num) {
   const positive = num >= 0
-  state.buffer[state.start++] = positive ? 1 : 0
-  lexint.encode(state, num * (positive ? 1 : -1))
+  const positiveBit = positive ? 0x80 : 0
+
+  const max = 123
+  num = num * (positive ? 1 : -1)
+  const x = num - max
+
+  const initialStart = state.start
+
+  if (num < max) {
+    state.buffer[state.start++] = num + positiveBit
+  } else if (num < 128) {
+    state.buffer[state.start++] = max + positiveBit
+    state.buffer[state.start++] = x
+  } else if (num < 0x10000) {
+    state.buffer[state.start++] = max + 1 + positiveBit
+    state.buffer[state.start++] = (x >> 8) & 0xff
+    state.buffer[state.start++] = x & 0xff
+  } else if (num < 0x1000000) {
+    state.buffer[state.start++] = max + 2 + positiveBit
+    state.buffer[state.start++] = x >> 16
+    state.buffer[state.start++] = (x >> 8) & 0xff
+    state.buffer[state.start++] = x & 0xff
+  } else if (num < 0x100000000) {
+    state.buffer[state.start++] = max + 3 + positiveBit
+    state.buffer[state.start++] = x >> 24
+    state.buffer[state.start++] = (x >> 16) & 0xff
+    state.buffer[state.start++] = (x >> 8) & 0xff
+    state.buffer[state.start++] = x & 0xff
+  } else {
+    // need to use Math here as bitwise ops are 32 bit
+    const exp = Math.floor(Math.log(x) / Math.log(2)) - 32
+    state.buffer[state.start++] = 0x7f + positiveBit
+
+    encode(state, exp)
+    const rem = x / Math.pow(2, exp - 11)
+
+    for (let i = 5; i >= 0; i--) {
+      state.buffer[state.start++] = (rem / Math.pow(2, 8 * i)) & 0xff
+    }
+  }
+
   if (!positive) {
-    for (let i = 1; i < state.end; i++) {
-      state.buffer[i] = state.buffer[i] ^ 0xff
+    // Flip all bits but the positive flag bit so negative numbers are lexicographically ordered.
+    state.buffer[initialStart] ^= 0x7f
+    for (let i = initialStart + 1; i < state.start; i++) {
+      state.buffer[i] ^= 0xff
     }
   }
 }
 
 function decode(state) {
-  const positive = state.buffer[state.start++]
+  const positive = (state.buffer[state.start] & 0x80) !== 0
   if (!positive) {
-    for (let i = 1; i < state.end; i++) {
-      state.buffer[i] = state.buffer[i] ^ 0xff
+    // Flip all bits but the positive flag bit
+    state.buffer[state.start] ^= 0x7f
+    for (let i = state.start + 1; i < state.end; i++) {
+      state.buffer[i] ^= 0xff
     }
+  } else {
+    state.buffer[state.start] &= 0x7f // remove flag
   }
-  return (positive ? 1 : -1) * lexint.decode(state)
+
+  const max = 123
+
+  if (state.end - state.start < 1) throw new Error('Out of bounds')
+
+  const flag = state.buffer[state.start++]
+
+  const positiveMultiplier = positive ? 1 : -1
+  if (flag < max) return positiveMultiplier * flag
+
+  if (state.end - state.start < flag - max + 1) {
+    throw new Error('Out of bounds.')
+  }
+
+  if (flag < 124) {
+    return positiveMultiplier * state.buffer[state.start++] + max
+  }
+
+  if (flag < 125) {
+    return (
+      positiveMultiplier *
+      ((state.buffer[state.start++] << 8) + state.buffer[state.start++] + max)
+    )
+  }
+
+  if (flag < 126) {
+    return (
+      positiveMultiplier *
+      ((state.buffer[state.start++] << 16) +
+        (state.buffer[state.start++] << 8) +
+        state.buffer[state.start++] +
+        max)
+    )
+  }
+
+  // << 24 result may be interpreted as negative
+  if (flag < 127) {
+    return (
+      positiveMultiplier *
+      (state.buffer[state.start++] * 0x1000000 +
+        (state.buffer[state.start++] << 16) +
+        (state.buffer[state.start++] << 8) +
+        state.buffer[state.start++] +
+        max)
+    )
+  }
+
+  const exp = decode(state)
+
+  if (state.end - state.start < 6) throw new Error('Out of bounds')
+
+  let rem = 0
+  for (let i = 5; i >= 0; i--) {
+    rem += state.buffer[state.start++] * Math.pow(2, 8 * i)
+  }
+
+  return positiveMultiplier * (rem * Math.pow(2, exp - 11) + max)
 }
 
 module.exports = {

--- a/test.js
+++ b/test.js
@@ -981,7 +981,7 @@ test('signedLexint', function (t) {
   for (n = -1; n > -Number.MAX_VALUE; n += skip) {
     const cur = enc.encode(enc.signedLexint, n)
     compare(n, enc.decode(enc.signedLexint, cur))
-    skip = -1 - Math.pow(245, Math.ceil(Math.log(-n) / Math.log(256)))
+    skip = -1 * (1 + Math.pow(245, Math.ceil(Math.log(-n) / Math.log(256))))
   }
   t.is(n, -Infinity, 'supports up to negative infinity')
   t.is(

--- a/test.js
+++ b/test.js
@@ -999,6 +999,15 @@ test('signedLexint', function (t) {
     'positive ints come after negative'
   )
 
+  t.is(
+    b4a.compare(
+      enc.encode(enc.signedLexint, -100),
+      enc.encode(enc.signedLexint, -1_000_000)
+    ),
+    1,
+    'negative numbers order correctly'
+  )
+
   t.end()
 
   function compare(a, b) {

--- a/test.js
+++ b/test.js
@@ -966,6 +966,61 @@ test('lexint: unpack', function (t) {
   }
 })
 
+test('signedLexint', function (t) {
+  let n
+  let skip = 1
+
+  for (n = 1; n < Number.MAX_VALUE; n += skip) {
+    const cur = enc.encode(enc.signedLexint, n)
+    compare(n, enc.decode(enc.signedLexint, cur))
+    skip = 1 + Math.pow(245, Math.ceil(Math.log(n) / Math.log(256)))
+  }
+  t.is(n, Infinity, 'supports up to positive infinity')
+
+  // Negative
+  for (n = -1; n > -Number.MAX_VALUE; n += skip) {
+    const cur = enc.encode(enc.signedLexint, n)
+    compare(n, enc.decode(enc.signedLexint, cur))
+    skip = -1 - Math.pow(245, Math.ceil(Math.log(-n) / Math.log(256)))
+  }
+  t.is(n, -Infinity, 'supports up to negative infinity')
+  t.is(
+    0,
+    enc.decode(enc.signedLexint, enc.encode(enc.signedLexint, 0)),
+    'supports 0'
+  )
+
+  t.is(
+    b4a.compare(
+      enc.encode(enc.signedLexint, 1_000_000),
+      enc.encode(enc.signedLexint, -1_000_000)
+    ),
+    1,
+    'positive ints come after negative'
+  )
+
+  t.end()
+
+  function compare(a, b) {
+    const desc = a + ' !=~ ' + b
+    if (/e\+\d+$/.test(a) || /e\+\d+$/.test(b)) {
+      if (
+        String(a).slice(0, 8) !== String(b).slice(0, 8) ||
+        /e\+(\d+)$/.exec(a)[1] !== /e\+(\d+)$/.exec(b)[1]
+      ) {
+        t.fail(desc)
+      }
+    } else {
+      if (
+        String(a).slice(0, 8) !== String(b).slice(0, 8) ||
+        String(a).length !== String(b).length
+      ) {
+        t.fail(desc)
+      }
+    }
+  }
+})
+
 test('date', function (t) {
   const d = new Date()
 

--- a/test.js
+++ b/test.js
@@ -1036,6 +1036,29 @@ test('date', function (t) {
   t.alike(enc.decode(enc.date, enc.encode(enc.date, d)), d)
 })
 
+test('lexdate', function (t) {
+  const d = new Date(-100)
+
+  t.alike(enc.decode(enc.lexdate, enc.encode(enc.lexdate, d)), d)
+  t.is(
+    b4a.compare(
+      enc.encode(enc.lexdate, d),
+      enc.encode(enc.lexdate, new Date(-1 * 24 * 60 * 60 * 1000))
+    ),
+    1
+  )
+
+  t.is(
+    b4a.compare(
+      enc.encode(enc.lexdate, d),
+      // 1 off but positive to trip up normal date encoder
+      enc.encode(enc.lexdate, new Date(99))
+    ),
+    -1,
+    'dates after epoch are sorted after preepoch dates'
+  )
+})
+
 test('any', function (t) {
   const o = {
     hello: 'world',

--- a/test.js
+++ b/test.js
@@ -1231,6 +1231,28 @@ test('lexdate', function (t) {
   )
 })
 
+test('lexdate & string', function (t) {
+  const d = new Date(-100)
+  const name = 'John'
+
+  const state = enc.state()
+  enc.lexdate.preencode(state, d)
+  t.alike(state, enc.state(0, 1))
+  enc.string.preencode(state, name)
+
+  state.buffer = b4a.alloc(state.end)
+
+  enc.lexdate.encode(state, d)
+  enc.string.encode(state, name)
+
+  state.start = 0
+  const dOut = enc.lexdate.decode(state)
+  const nameOut = enc.string.decode(state)
+
+  t.alike(d, dOut, 'date decoded')
+  t.alike(name, nameOut, 'name decoded')
+})
+
 test('any', function (t) {
   const o = {
     hello: 'world',

--- a/test.js
+++ b/test.js
@@ -975,7 +975,7 @@ test('signedLexint', function (t) {
     compare(n, enc.decode(enc.signedLexint, cur))
     skip = 1 + Math.pow(245, Math.ceil(Math.log(n) / Math.log(256)))
   }
-  t.is(n, Infinity, 'supports up to positive infinity')
+  t.is(n, Infinity, 'supports positive numbers up to positive infinity')
 
   // Negative
   for (n = -1; n > -Number.MAX_VALUE; n += skip) {
@@ -983,7 +983,7 @@ test('signedLexint', function (t) {
     compare(n, enc.decode(enc.signedLexint, cur))
     skip = -1 * (1 + Math.pow(245, Math.ceil(Math.log(-n) / Math.log(256))))
   }
-  t.is(n, -Infinity, 'supports up to negative infinity')
+  t.is(n, -Infinity, 'supports negative numbers up to negative infinity')
   t.is(
     0,
     enc.decode(enc.signedLexint, enc.encode(enc.signedLexint, 0)),
@@ -1028,6 +1028,178 @@ test('signedLexint', function (t) {
       }
     }
   }
+})
+
+test('signed-lexint: big numbers', function (t) {
+  t.plan(2)
+
+  let prev = enc.encode(enc.signedLexint, 0)
+
+  let n
+  let skip = 1
+
+  for (n = 1; n < Number.MAX_VALUE; n += skip) {
+    const cur = enc.encode(enc.signedLexint, n)
+    if (b4a.compare(cur, prev) < 1) break
+    prev = cur
+    skip = 1 + Math.pow(245, Math.ceil(Math.log(n) / Math.log(256)))
+  }
+  t.is(n, Infinity)
+
+  prev = enc.encode(enc.signedLexint, 0)
+  for (n = -1; n > -Number.MAX_VALUE; n += skip) {
+    const cur = enc.encode(enc.signedLexint, n)
+    if (b4a.compare(cur, prev) > -1) break
+    prev = cur
+    skip = -1 * (1 + Math.pow(245, Math.ceil(Math.log(-n) / Math.log(256))))
+  }
+  t.is(n, -Infinity)
+})
+
+test('signed-lexint: range precision', function (t) {
+  t.plan(4)
+  const a = 1e55
+  const b = 1.0000000000001e55
+  const ha = enc.encode(enc.signedLexint, a).toString('hex')
+  const hb = enc.encode(enc.signedLexint, b).toString('hex')
+  t.not(a, b)
+  t.not(ha, hb)
+
+  const haNeg = enc.encode(enc.signedLexint, -a).toString('hex')
+  const hbNeg = enc.encode(enc.signedLexint, -b).toString('hex')
+  t.not(-a, -b)
+  t.not(haNeg, hbNeg)
+})
+
+test('signed-lexint: range precision', function (t) {
+  let prev = enc.encode(enc.signedLexint, 0)
+  const skip = 0.000000001e55
+  for (let i = 0, n = 1e55; i < 1000; n = 1e55 + skip * ++i) {
+    const cur = enc.encode(enc.signedLexint, n)
+    if (b4a.compare(cur, prev) < 1) t.fail('cur <= prev')
+    prev = cur
+  }
+  t.ok(true)
+
+  // Negative
+  for (let i = 0, n = -1e55; i < 1000; n = -1e55 - skip * ++i) {
+    const cur = enc.encode(enc.signedLexint, n)
+    if (b4a.compare(cur, prev) > -1) t.fail('cur >= prev')
+    prev = cur
+  }
+  t.ok(true)
+
+  t.end()
+})
+
+test('signed-lexint: small numbers', function (t) {
+  let prev = enc.encode(enc.signedLexint, 0)
+  for (let n = 1; n < 256 * 256 * 16; n++) {
+    const cur = enc.encode(enc.signedLexint, n)
+    if (b4a.compare(cur, prev) < 1) t.fail('cur <= prev')
+    prev = cur
+  }
+  t.ok(true)
+
+  prev = enc.encode(enc.signedLexint, 0)
+  for (let n = -1; n > -256 * 256 * 16; n--) {
+    const cur = enc.encode(enc.signedLexint, n)
+    if (b4a.compare(cur, prev) > -1) t.fail('cur >= prev')
+    prev = cur
+  }
+  t.ok(true)
+  t.end()
+})
+
+test('signed-lexint: throws', function (t) {
+  t.exception(() => {
+    enc.decode(enc.signedLexint, b4a.alloc(1, 251))
+  })
+
+  let num = 124
+
+  const state = enc.state()
+
+  enc.signedLexint.preencode(state, num)
+  state.buffer = b4a.alloc(state.end - state.start)
+  enc.signedLexint.encode(state, num)
+
+  t.exception(() => {
+    enc.decode(
+      enc.signedLexint,
+      state.buffer.subarray(0, state.buffer.byteLength - 2)
+    )
+  })
+
+  num <<= 8
+
+  state.start = 0
+  state.end = 0
+  state.buffer = null
+
+  enc.signedLexint.preencode(state, num)
+  state.buffer = b4a.alloc(state.end - state.start)
+  enc.signedLexint.encode(state, num)
+
+  t.exception(() => {
+    enc.decode(
+      enc.signedLexint,
+      state.buffer.subarray(0, state.buffer.byteLength - 2)
+    )
+  })
+
+  num <<= 8
+
+  state.start = 0
+  state.end = 0
+  state.buffer = null
+
+  enc.signedLexint.preencode(state, num)
+  state.buffer = b4a.alloc(state.end - state.start)
+  enc.signedLexint.encode(state, num)
+
+  t.exception(() => {
+    enc.decode(
+      enc.signedLexint,
+      state.buffer.subarray(0, state.buffer.byteLength - 2)
+    )
+  })
+
+  num *= 256
+
+  state.start = 0
+  state.end = 0
+  state.buffer = null
+
+  enc.signedLexint.preencode(state, num)
+  state.buffer = b4a.alloc(state.end - state.start)
+  enc.signedLexint.encode(state, num)
+
+  t.exception(() => {
+    enc.decode(
+      enc.signedLexint,
+      state.buffer.subarray(0, state.buffer.byteLength - 2)
+    )
+  })
+
+  num *= 256 * 256
+
+  state.start = 0
+  state.end = 0
+  state.buffer = null
+
+  enc.signedLexint.preencode(state, num)
+  state.buffer = b4a.alloc(state.end - state.start)
+  enc.signedLexint.encode(state, num)
+
+  t.exception(() => {
+    enc.decode(
+      enc.signedLexint,
+      state.buffer.subarray(0, state.buffer.byteLength - 2)
+    )
+  })
+
+  t.end()
 })
 
 test('date', function (t) {


### PR DESCRIPTION
Lexicographic encoder for dates would be nice for range queries of timestamps. To support pre-epoch dates, a signed version of the `lexint` encoder was needed.

I initially opted to using the first byte for a boolean for whether the value is positive or not. But then adjusted a copy of the lexint (en/dec)coder so that it uses 1 bit from the first byte as the positive flag. This means the first byte can hold only a max magnitude of `122`. The non-flag bits of negative numbers are flipped from their positive counterparts so the lexicographic ordering is preserved.