### PR TITLE
Add `nonNullableBuffer` encoding

### DIFF
--- a/index.js
+++ b/index.js
@@ -317,6 +317,20 @@ const buffer = (exports.buffer = {
   }
 })
 
+exports.nonNullableBuffer = {
+  preencode(state, b) {
+    uint8array.preencode(state, b)
+  },
+  encode(state, b) {
+    uint8array.encode(state, b)
+  },
+  decode(state) {
+    const len = uint.decode(state)
+    if (state.end - state.start < len) throw new Error('Out of bounds')
+    return state.buffer.subarray(state.start, (state.start += len))
+  }
+}
+
 exports.binary = {
   ...buffer,
   preencode(state, b) {

--- a/test.js
+++ b/test.js
@@ -311,6 +311,58 @@ test('buffer', function (t) {
   t.exception(() => enc.buffer.decode(state))
 })
 
+test('non-nullable nonNullableBuffer', function (t) {
+  const state = enc.state()
+
+  enc.nonNullableBuffer.preencode(state, b4a.from('hi'))
+  t.alike(state, enc.state(0, 3))
+  enc.nonNullableBuffer.preencode(state, b4a.from('hello'))
+  t.alike(state, enc.state(0, 9))
+  enc.nonNullableBuffer.preencode(state, b4a.alloc(0))
+  t.alike(state, enc.state(0, 10), 'preencode empty nonNullableBuffer')
+
+  state.buffer = b4a.alloc(state.end)
+  enc.nonNullableBuffer.encode(state, b4a.from('hi'))
+  t.alike(
+    state,
+    enc.state(3, 10, b4a.from('\x02hi\x00\x00\x00\x00\x00\x00\x00')),
+    'encode "hi"'
+  )
+  enc.nonNullableBuffer.encode(state, b4a.from('hello'))
+  t.alike(
+    state,
+    enc.state(9, 10, b4a.from('\x02hi\x05hello\x00')),
+    'encode "hello"'
+  )
+  enc.nonNullableBuffer.encode(state, b4a.alloc(0))
+  t.alike(state, enc.state(10, 10, b4a.from('\x02hi\x05hello\x00')))
+
+  state.start = 0
+  t.alike(enc.nonNullableBuffer.decode(state), b4a.from('hi'))
+  t.alike(
+    enc.nonNullableBuffer.decode(state),
+    b4a.from('hello'),
+    'decode "hello"'
+  )
+  t.alike(
+    enc.nonNullableBuffer.decode(state),
+    b4a.alloc(0),
+    'decode empty nonNullableBuffer'
+  )
+  t.is(state.start, state.end)
+
+  t.alike(
+    enc.decode(
+      enc.nonNullableBuffer,
+      enc.encode(enc.nonNullableBuffer, Buffer.alloc(0))
+    ),
+    Buffer.alloc(0),
+    'empty nonNullableBuffer can encode then decode as identity'
+  )
+
+  t.exception(() => enc.nonNullableBuffer.decode(state))
+})
+
 test('arraybuffer', function (t) {
   const state = enc.state()
 

--- a/test.js
+++ b/test.js
@@ -289,24 +289,44 @@ test('buffer', function (t) {
   enc.buffer.preencode(state, b4a.from('hello'))
   t.alike(state, enc.state(0, 9))
   enc.buffer.preencode(state, null)
-  t.alike(state, enc.state(0, 10))
+  t.alike(state, enc.state(0, 10), 'preencode null')
+  enc.buffer.preencode(state, b4a.alloc(0))
+  t.alike(state, enc.state(0, 11), 'preencode empty buffer')
 
   state.buffer = b4a.alloc(state.end)
   enc.buffer.encode(state, b4a.from('hi'))
   t.alike(
     state,
-    enc.state(3, 10, b4a.from('\x02hi\x00\x00\x00\x00\x00\x00\x00'))
+    enc.state(3, 11, b4a.from('\x02hi\x00\x00\x00\x00\x00\x00\x00\x00')),
+    'encode "hi"'
   )
   enc.buffer.encode(state, b4a.from('hello'))
-  t.alike(state, enc.state(9, 10, b4a.from('\x02hi\x05hello\x00')))
+  t.alike(
+    state,
+    enc.state(9, 11, b4a.from('\x02hi\x05hello\x00\x00')),
+    'encode "hello"'
+  )
   enc.buffer.encode(state, null)
-  t.alike(state, enc.state(10, 10, b4a.from('\x02hi\x05hello\x00')))
+  t.alike(
+    state,
+    enc.state(10, 11, b4a.from('\x02hi\x05hello\x00\x00')),
+    'encode null'
+  )
+  enc.buffer.encode(state, b4a.alloc(0))
+  t.alike(state, enc.state(11, 11, b4a.from('\x02hi\x05hello\x00\x00')))
 
   state.start = 0
   t.alike(enc.buffer.decode(state), b4a.from('hi'))
   t.alike(enc.buffer.decode(state), b4a.from('hello'))
-  t.is(enc.buffer.decode(state), null)
+  t.is(enc.buffer.decode(state), null, 'decode null')
+  t.alike(enc.buffer.decode(state), null, 'decode empty buffer as null')
   t.is(state.start, state.end)
+
+  t.alike(
+    enc.decode(enc.buffer, enc.encode(enc.buffer, Buffer.alloc(0))),
+    null,
+    'empty buffer will encode then decode as null'
+  )
 
   t.exception(() => enc.buffer.decode(state))
 })


### PR DESCRIPTION
This encoding only supports buffers which differs from `buffer` which supports `null` or non-empty buffers. So `nonNullableBuffer` supports empty buffers but not `null`.