### PR TITLE
Make `buffer` strictly buffers & add `optionalBuffer` for old `buffer` functionality

### DIFF
--- a/index.js
+++ b/index.js
@@ -314,6 +314,23 @@ const buffer = (exports.buffer = {
   }
 })
 
+exports.optionalBuffer = {
+  preencode(state, b) {
+    if (b) uint8array.preencode(state, b)
+    else state.end++
+  },
+  encode(state, b) {
+    if (b) uint8array.encode(state, b)
+    else state.buffer[state.start++] = 0
+  },
+  decode(state) {
+    const len = uint.decode(state)
+    if (len === 0) return null
+    if (state.end - state.start < len) throw new Error('Out of bounds')
+    return state.buffer.subarray(state.start, (state.start += len))
+  }
+}
+
 exports.binary = {
   ...buffer,
   preencode(state, b) {

--- a/index.js
+++ b/index.js
@@ -302,16 +302,13 @@ exports.float64 = {
 
 const buffer = (exports.buffer = {
   preencode(state, b) {
-    if (b) uint8array.preencode(state, b)
-    else state.end++
+    uint8array.preencode(state, b)
   },
   encode(state, b) {
-    if (b) uint8array.encode(state, b)
-    else state.buffer[state.start++] = 0
+    uint8array.encode(state, b)
   },
   decode(state) {
     const len = uint.decode(state)
-    if (len === 0) return null
     if (state.end - state.start < len) throw new Error('Out of bounds')
     return state.buffer.subarray(state.start, (state.start += len))
   }

--- a/raw.js
+++ b/raw.js
@@ -19,16 +19,13 @@ exports = module.exports = {
 
 const buffer = (exports.buffer = {
   preencode(state, b) {
-    if (b) uint8array.preencode(state, b)
-    else state.end++
+    uint8array.preencode(state, b)
   },
   encode(state, b) {
-    if (b) uint8array.encode(state, b)
-    else state.buffer[state.start++] = 0
+    uint8array.encode(state, b)
   },
   decode(state) {
     const b = state.buffer.subarray(state.start)
-    if (b.byteLength === 0) return null
     state.start = state.end
     return b
   }

--- a/test.js
+++ b/test.js
@@ -658,6 +658,24 @@ test('raw string', function (t) {
   t.is(enc.raw.string.decode(state), '')
 })
 
+test('raw buffer', function (t) {
+  const state = enc.state()
+
+  enc.raw.string.preencode(state, b4a.from('hello'))
+  t.alike(state, enc.state(0, 5))
+  enc.raw.string.preencode(state, b4a.from(' world'))
+  t.alike(state, enc.state(0, 11))
+
+  state.buffer = b4a.alloc(state.end)
+  enc.raw.buffer.encode(state, b4a.from('hello'))
+  enc.raw.buffer.encode(state, b4a.from(' world'))
+  t.alike(state, enc.state(11, 11, b4a.from('hello world')))
+
+  state.start = 0
+  t.alike(enc.raw.buffer.decode(state), b4a.from('hello world'))
+  t.alike(enc.raw.buffer.decode(state), b4a.alloc(0))
+})
+
 test('fixed32', function (t) {
   const state = enc.state()
 

--- a/test.js
+++ b/test.js
@@ -288,7 +288,7 @@ test('buffer', function (t) {
   t.alike(state, enc.state(0, 3))
   enc.buffer.preencode(state, b4a.from('hello'))
   t.alike(state, enc.state(0, 9))
-  enc.buffer.preencode(state, null)
+  enc.buffer.preencode(state, b4a.alloc(0))
   t.alike(state, enc.state(0, 10))
 
   state.buffer = b4a.alloc(state.end)
@@ -299,13 +299,13 @@ test('buffer', function (t) {
   )
   enc.buffer.encode(state, b4a.from('hello'))
   t.alike(state, enc.state(9, 10, b4a.from('\x02hi\x05hello\x00')))
-  enc.buffer.encode(state, null)
+  enc.buffer.encode(state, b4a.alloc(0))
   t.alike(state, enc.state(10, 10, b4a.from('\x02hi\x05hello\x00')))
 
   state.start = 0
   t.alike(enc.buffer.decode(state), b4a.from('hi'))
   t.alike(enc.buffer.decode(state), b4a.from('hello'))
-  t.is(enc.buffer.decode(state), null)
+  t.alike(enc.buffer.decode(state), b4a.alloc(0))
   t.is(state.start, state.end)
 
   t.exception(() => enc.buffer.decode(state))

--- a/test.js
+++ b/test.js
@@ -311,6 +311,40 @@ test('buffer', function (t) {
   t.exception(() => enc.buffer.decode(state))
 })
 
+test('optionalBuffer', function (t) {
+  const state = enc.state()
+
+  enc.optionalBuffer.preencode(state, b4a.from('hi'))
+  t.alike(state, enc.state(0, 3))
+  enc.optionalBuffer.preencode(state, b4a.from('hello'))
+  t.alike(state, enc.state(0, 9))
+  enc.optionalBuffer.preencode(state, null)
+  enc.optionalBuffer.preencode(state, b4a.alloc(0))
+  t.alike(state, enc.state(0, 11))
+
+  state.buffer = b4a.alloc(state.end)
+  enc.optionalBuffer.encode(state, b4a.from('hi'))
+  t.alike(
+    state,
+    enc.state(3, 11, b4a.from('\x02hi\x00\x00\x00\x00\x00\x00\x00\x00'))
+  )
+  enc.optionalBuffer.encode(state, b4a.from('hello'))
+  t.alike(state, enc.state(9, 11, b4a.from('\x02hi\x05hello\x00\x00')))
+  enc.optionalBuffer.encode(state, null)
+  t.alike(state, enc.state(10, 11, b4a.from('\x02hi\x05hello\x00\x00')))
+  enc.optionalBuffer.encode(state, b4a.alloc(0))
+  t.alike(state, enc.state(11, 11, b4a.from('\x02hi\x05hello\x00\x00')))
+
+  state.start = 0
+  t.alike(enc.optionalBuffer.decode(state), b4a.from('hi'))
+  t.alike(enc.optionalBuffer.decode(state), b4a.from('hello'))
+  t.is(enc.optionalBuffer.decode(state), null)
+  t.is(enc.optionalBuffer.decode(state), null, 'empty buffer decodes as null')
+  t.is(state.start, state.end)
+
+  t.exception(() => enc.optionalBuffer.decode(state))
+})
+
 test('arraybuffer', function (t) {
   const state = enc.state()
 


### PR DESCRIPTION
Now `buffer` returns an empty buffer which previously when encoded -> decoded was `null` since `null` and empty buffers were encoded the same.

To main original functionality, `optionalBuffer` was added. This encoding will encode empty Buffers the same as `null` and decode always as `null`.