### PR TITLE
reject integers beyond the maximum safe integer instead of misrounding

### DIFF
--- a/index.js
+++ b/index.js
@@ -1088,4 +1088,11 @@ function zigZagEncodeBigInt(n) {
 function validateUint(n) {
   if (n >= 0 === false /* Handles NaN as well */)
     throw new Error('uint must be positive')
+  // Beyond this, Number arithmetic loses precision and silently corrupts the
+  // encoding. The zig-zag int codecs route through here too, so this also
+  // guards int values whose doubled magnitude exceeds the safe range.
+  if (n > Number.MAX_SAFE_INTEGER)
+    throw new Error(
+      'uint is greater than the maximum safe integer, use biguint'
+    )
 }

--- a/index.js
+++ b/index.js
@@ -1093,6 +1093,6 @@ function validateUint(n) {
   // guards int values whose doubled magnitude exceeds the safe range.
   if (n > Number.MAX_SAFE_INTEGER)
     throw new Error(
-      'uint is greater than the maximum safe integer, use biguint'
+      'integer is greater than the maximum safe integer, use biguint/bigint'
     )
 }

--- a/test.js
+++ b/test.js
@@ -217,6 +217,22 @@ test('int', function (t) {
   t.exception(() => enc.int.decode(state))
 })
 
+test('integers beyond the safe range throw instead of silently corrupting', function (t) {
+  // The safe-integer boundary still encodes and round-trips.
+  const state = enc.state()
+  enc.uint64.preencode(state, Number.MAX_SAFE_INTEGER)
+  state.buffer = b4a.alloc(state.end)
+  enc.uint64.encode(state, Number.MAX_SAFE_INTEGER)
+  state.start = 0
+  t.is(enc.uint64.decode(state), Number.MAX_SAFE_INTEGER)
+
+  // Beyond it both uint and the zig-zag int codecs reject rather than misround.
+  const big = enc.state(0, 64, b4a.alloc(64))
+  t.exception(() => enc.uint64.encode(big, Number.MAX_SAFE_INTEGER + 1))
+  t.exception(() => enc.int56.encode(big, -(2 ** 53 - 1)))
+  t.exception(() => enc.int.encode(big, 2 ** 53))
+})
+
 test('float64', function (t) {
   const state = enc.state()
 


### PR DESCRIPTION
Fixes #52. `validateUint` only checked `n >= 0`, so `uint56`/`uint64` and the zig-zag int codecs silently misrounded (and failed to round-trip) once a value passed the safe-integer range — e.g. `int56.encode(-(2^53-1))` produced bytes that decode to a positive number. Adds an upper-bound check in `validateUint` (the chokepoint every uint encoder, and thus the zig-zag path, routes through) so it throws instead, directing callers to the biguint/bigint codecs for larger values. The safe boundary itself still encodes and round-trips.