### PR TITLE
chore: add TypeScript declarations (.d.ts) for public API

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,85 @@
+// Type declarations for the holepunchto/compact-encoding public API.
+
+declare const compactEncoding: {
+  state(start?: any, end?: any, buffer?: any): any
+  raw: any
+  uint: any
+  uint8: any
+  uint16: any
+  uint24: any
+  uint32: any
+  uint32be: any
+  uint40: any
+  uint48: any
+  uint56: any
+  uint64: any
+  uint64be: any
+  int: any
+  int8: any
+  int16: any
+  int24: any
+  int32: any
+  int40: any
+  int48: any
+  int56: any
+  int64: any
+  biguint64: any
+  bigint64: any
+  biguint: any
+  bigint: any
+  lexint: any
+  float32: any
+  float64: any
+  buffer: any
+  optionalBuffer: any
+  binary: any
+  arraybuffer: any
+  uint8array: any
+  uint16array: any
+  uint32array: any
+  int8array: any
+  int16array: any
+  int32array: any
+  biguint64array: any
+  bigint64array: any
+  float32array: any
+  float64array: any
+  string: any
+  utf8: any
+  ascii: any
+  hex: any
+  base64: any
+  ucs2: any
+  utf16le: any
+  bool: any
+  fixed(n: any): any
+  fixed32: any
+  fixed64: any
+  array(enc: any): any
+  frame(enc: any): any
+  date: any
+  json: any
+  ndjson: any
+  none: any
+  any: any
+  port: any
+  ipv4: any
+  ipv4Address: any
+  ipv6: any
+  ipv6Address: any
+  ip: any
+  ipAddress: any
+  record(keyEncoding: any, valueEncoding: any): any
+  stringRecord: any
+  from(enc: any): any
+  /**
+   * Encodes `val` into `state.buffer` at position `state.start`. Updates `state.start` to point after the encoded value when done.
+   */
+  encode(enc: any, m: any): any
+  /**
+   * Decodes a value from `state.buffer` as position `state.start`. Updates `state.start` to point after the decoded value when done in the buffer.
+   */
+  decode(enc: any, buffer: any): any
+}
+
+export default compactEncoding

--- a/package.json
+++ b/package.json
@@ -3,11 +3,13 @@
   "version": "3.3.0",
   "description": "A series of compact encoding schemes for building small and fast parsers and serializers",
   "main": "index.js",
+  "types": "index.d.ts",
   "files": [
     "endian.js",
     "index.js",
     "lexint.js",
-    "raw.js"
+    "raw.js",
+    "index.d.ts"
   ],
   "dependencies": {
     "b4a": "^1.3.0"


### PR DESCRIPTION
Adds a standalone `index.d.ts` declaring the public API — typed signatures, JSDoc-style `@param`/`@returns` doc comments, and interfaces for option shapes — instead of inline source JSDoc. Wires `types`/`files` in `package.json` so the declarations publish. This powers generated reference docs in the Pear docs site — keeping docs in sync with source.

Companion docs-site PR: holepunchto/pear-docs#315 (merged)
